### PR TITLE
Add target streamer setup

### DIFF
--- a/llvm-mcad.cpp
+++ b/llvm-mcad.cpp
@@ -290,6 +290,7 @@ int main(int argc, char **argv) {
   // Initialize targets
   InitializeAllTargetInfos();
   InitializeAllTargetMCs();
+  InitializeAllAsmParsers();
   // Although `llvm-mcad` doesn't use the disassembler, some broker
   // plugin might use it. However, if we call InitializeAllDisassemblers
   // in the broker plugin, it will fail to retrieve the correct `Target`
@@ -297,7 +298,6 @@ int main(int argc, char **argv) {
   // Therefore, we have little choises but initializing them here.
   // FIXME: Put "require disassembler" as a Broker feature
   // and initialize them only when that feature is given.
-  // FIXME: What about AsmParser?
   InitializeAllDisassemblers();
 
   // Print all available targets in `--verison`


### PR DESCRIPTION
On RISCV I was getting a segmentation fault because [getTargetStreamer](https://github.com/sifive/riscv-llvm-internal/blob/ede847f75b9c6719a9a03e02c9ab27d930464d4b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp#L77) returned null since the `TargetStreamer` in the `MCStreamer` class was not set.

On X86, it's not set either but for some reason it never calls the `X86AsmParser::targetStreamer()` function so it never crashes.

The code below is heavily inspired by `riscv-llvm-internal/llvm/tools/llvm-exegesis/lib/SnippetFile.cpp`. Now, we are creating the `TargetAsmParser` as desired. This leads to a new crash on x280 but I think thats because of a scheduler model bug.