### PR TITLE
add SourceMgr to MCContext

### DIFF
--- a/BrokerFacade.h
+++ b/BrokerFacade.h
@@ -8,6 +8,7 @@ class MCAsmInfo;
 class MCContext;
 class MCSubtargetInfo;
 class MCInstrInfo;
+class SourceMgr;
 
 namespace mcad {
 class Broker;
@@ -35,6 +36,8 @@ public:
   const MCInstrInfo &getInstrInfo() const;
 
   const MCSubtargetInfo &getSTI() const;
+
+  llvm::SourceMgr &getSourceMgr() const;
 };
 } // end namespace mcad
 } // end namespace llvm

--- a/Brokers/AsmFileBroker.cpp
+++ b/Brokers/AsmFileBroker.cpp
@@ -21,8 +21,9 @@ static cl::opt<std::string>
 
 AsmFileBroker::AsmFileBroker(const Target &T, MCContext &Ctx,
                              const MCAsmInfo &MAI, const MCSubtargetInfo &STI,
-                             const MCInstrInfo &MII)
-  : SrcMgr(), CRG(T, SrcMgr, Ctx, MAI, STI, MII),
+                             const MCInstrInfo &MII,
+                             llvm::SourceMgr &SM)
+  : SrcMgr(SM), CRG(T, SrcMgr, Ctx, MAI, STI, MII),
     Regions(nullptr), CurInstIdx(0U), IsInvalid(false) {
   llvm::InitializeAllAsmParsers();
 
@@ -39,7 +40,8 @@ void AsmFileBroker::Register(BrokerFacade BF) {
   BF.setBroker(
     std::make_unique<AsmFileBroker>(BF.getTarget(), BF.getCtx(),
                                     BF.getAsmInfo(), BF.getSTI(),
-                                    BF.getInstrInfo()));
+                                    BF.getInstrInfo(),
+                                    BF.getSourceMgr()));
 }
 
 bool AsmFileBroker::parseIfNeeded() {

--- a/Brokers/AsmFileBroker.h
+++ b/Brokers/AsmFileBroker.h
@@ -11,7 +11,7 @@ namespace mcad {
 // A broker that simply reads from local assembly file.
 // Useful for testing.
 class AsmFileBroker : public Broker {
-  llvm::SourceMgr SrcMgr;
+  llvm::SourceMgr &SrcMgr;
   mca::AsmCodeRegionGenerator CRG;
 
   const mca::CodeRegions *Regions;
@@ -27,7 +27,8 @@ class AsmFileBroker : public Broker {
 public:
   AsmFileBroker(const Target &T, MCContext &C,
                 const MCAsmInfo &A, const MCSubtargetInfo &S,
-                const MCInstrInfo &I);
+                const MCInstrInfo &I,
+                llvm::SourceMgr &SM);
 
   static void Register(BrokerFacade BF);
 

--- a/MCAWorker.cpp
+++ b/MCAWorker.cpp
@@ -97,6 +97,10 @@ const MCSubtargetInfo &BrokerFacade::getSTI() const {
   return Worker.STI;
 }
 
+SourceMgr &BrokerFacade::getSourceMgr() const {
+  return Worker.SM;
+}
+
 MCAWorker::MCAWorker(const Target &T,
                      const MCSubtargetInfo &TheSTI,
                      mca::Context &MCA,
@@ -107,10 +111,11 @@ MCAWorker::MCAWorker(const Target &T,
                      const MCAsmInfo &AI,
                      const MCInstrInfo &II,
                      MCInstPrinter &IP,
-                     mca::MetadataRegistry &MDR)
+                     mca::MetadataRegistry &MDR,
+                     llvm::SourceMgr &SM)
   : TheTarget(T), STI(TheSTI),
     MCAIB(IB), Ctx(C), MAI(AI), MCII(II), MIP(IP), MDR(MDR),
-    TheMCA(MCA), MCAPO(PO), MCAOF(OF),
+    TheMCA(MCA), MCAPO(PO), MCAOF(OF), SM(SM),
     NumTraceMIs(0U), GetTraceMISize([this]{ return NumTraceMIs; }),
     GetRecycledInst([this](const mca::InstrDesc &Desc) -> mca::Instruction* {
                       if (RecycledInsts.count(&Desc)) {

--- a/MCAWorker.h
+++ b/MCAWorker.h
@@ -54,6 +54,7 @@ class MCAWorker {
   // SummaryView will only take reference of it.
   std::function<size_t(void)> GetTraceMISize;
 
+  llvm::SourceMgr &SM;
   mca::IncrementalSourceMgr SrcMgr;
 
   std::unordered_map<const mca::InstrDesc*,
@@ -85,7 +86,8 @@ public:
             const MCAsmInfo &MAI,
             const MCInstrInfo &II,
             MCInstPrinter &IP,
-            mca::MetadataRegistry &MDR
+            mca::MetadataRegistry &MDR,
+            llvm::SourceMgr &SM
             );
 
   BrokerFacade getBrokerFacade() {

--- a/llvm-mcad.cpp
+++ b/llvm-mcad.cpp
@@ -330,8 +330,9 @@ int main(int argc, char **argv) {
             TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
   assert(MAI);
 
+  llvm::SourceMgr SM;
   auto Ctx = std::make_unique<MCContext>(TheTriple,
-                                         MAI.get(), MRI.get(), STI.get());
+                                         MAI.get(), MRI.get(), STI.get(), &SM);
   std::unique_ptr<MCObjectFileInfo> MOFI(
     TheTarget->createMCObjectFileInfo(*Ctx, /*PIC=*/false));
   Ctx->setObjectFileInfo(MOFI.get());
@@ -373,7 +374,7 @@ int main(int argc, char **argv) {
   mcad::MCAWorker Worker(*TheTarget, *STI,
                          MCA, PO, IB, OF,
                          *Ctx, *MAI, *MCII, *IP, 
-                         *MDR);
+                         *MDR, SM);
 
   if(int Ret = initializeProfilers())
     return Ret;


### PR DESCRIPTION
`MCContext.cpp:984` would trigger an assertion failure because `Either SourceMgr should be available`. This assertion would be triggered when the `llvm::SourceMgr` (not to be confused with `llvm::mca::SourceMgr` was not set in the `MCContext` object.

On RISCV, this error was triggered by multiple instructions. Two of these such instructions was a `vadd.vi` or `vse32.v`. However, it is not limited to these two instructions, nor is it limited to just the vector instruction set.

In order to fix this problem, we construct the `MCContext` by passing it the `llvm::SourceMgr` it expects. The `AsmFileBroker` also wants the `llvm::SourceMgr` so we must pass the one we create for the `MCContext` in `llvm-mcad` to the `MCAWorker` which constructs a `AsmFileBroker` with the same `SourceMgr`.

In the future, I would like to clean things up. I think there are some opportunities to clean up the dependency injection that occurs and the `BrokerFacade` seems unnecessary (or needs some refactoring).