### PR TITLE
Fix dangling CustomBehaviour

### DIFF
--- a/MCAWorker.cpp
+++ b/MCAWorker.cpp
@@ -142,10 +142,8 @@ void MCAWorker::resetPipeline() {
   MCAIB.clear();
   SrcMgr.clear();
 
-  // FIXME: Can we make CustomBehaviour optional?
-  mca::IncrementalSourceMgr DummyCSM;
-  mca::CustomBehaviour DummyCB(STI, DummyCSM, MCII);
-  MCAPipeline = std::move(TheMCA.createDefaultPipeline(MCAPO, SrcMgr, DummyCB));
+  CB = new mca::CustomBehaviour(STI, SrcMgr, MCII);
+  MCAPipeline = std::move(TheMCA.createDefaultPipeline(MCAPO, SrcMgr, *CB));
   assert(MCAPipeline);
 
   MCAPipelinePrinter

--- a/MCAWorker.h
+++ b/MCAWorker.h
@@ -30,6 +30,7 @@ class PipelineOptions;
 class PipelinePrinter;
 class InstrDesc;
 class Instruction;
+class CustomBehaviour;
 } // end namespace mca
 
 namespace mcad {
@@ -54,6 +55,8 @@ class MCAWorker {
   // SummaryView will only take reference of it.
   std::function<size_t(void)> GetTraceMISize;
 
+
+  mca::CustomBehaviour *CB;
   mca::IncrementalSourceMgr SrcMgr;
 
   std::unordered_map<const mca::InstrDesc*,


### PR DESCRIPTION
The `CustomBehaviour` in `resetPipeline` is created on the stack and after `resetPipeline`, it can be clobbered. But `createDefaultPipeline` ends up saving a reference to the `CustomBehaviour` in the `InOrderIssueStage`. When that stage calls `CB.checkCustomHazard(...)`, `CB` might have been clobbered over, leading to a segmentation fault.

Now that it is allocated on the heap, this problem no longer occurs.